### PR TITLE
Skullywag's have a harder time opening strong doors

### DIFF
--- a/Source/RimWorld_Mechanoids/Mechanoids/Verb_UnlockDoor.cs
+++ b/Source/RimWorld_Mechanoids/Mechanoids/Verb_UnlockDoor.cs
@@ -1,3 +1,4 @@
+using System;
 using HarmonyLib;
 using RimWorld;
 using UnityEngine;
@@ -35,7 +36,11 @@ namespace MoreMechanoids
             CasterPawn.rotationTracker.Face(door.DrawPos);
 
             var nonMissChance = Traverse.Create(this).Method("GetNonMissChance", (LocalTargetInfo)door).GetValue<float>();
-            if(Rand.Chance(nonMissChance))
+            // Wood door ~100%, steel (160hp) ~69%, granite (270hp) ~41%, plasteel (450hp) ~24%
+            var hpChance = 1/(door.HitPoints / 110.0f);
+            var unlockChance = Math.Min(nonMissChance, hpChance);
+            
+            if(Rand.Chance(unlockChance))
             {
                 UnlockDoor(door);
             }

--- a/Source/RimWorld_Mechanoids/Mechanoids/Verb_UnlockDoor.cs
+++ b/Source/RimWorld_Mechanoids/Mechanoids/Verb_UnlockDoor.cs
@@ -37,7 +37,7 @@ namespace MoreMechanoids
 
             var nonMissChance = Traverse.Create(this).Method("GetNonMissChance", (LocalTargetInfo)door).GetValue<float>();
             // Wood door ~100%, steel (160hp) ~69%, granite (270hp) ~41%, plasteel (450hp) ~24%
-            var hpChance = 1/(Math.Max(door.HitPoints, 1) / 110.0f);
+            var hpChance = 110.0f / Math.Max(door.HitPoints, 1);
             var unlockChance = Math.Min(nonMissChance, hpChance);
             
             if(Rand.Chance(unlockChance))

--- a/Source/RimWorld_Mechanoids/Mechanoids/Verb_UnlockDoor.cs
+++ b/Source/RimWorld_Mechanoids/Mechanoids/Verb_UnlockDoor.cs
@@ -37,7 +37,7 @@ namespace MoreMechanoids
 
             var nonMissChance = Traverse.Create(this).Method("GetNonMissChance", (LocalTargetInfo)door).GetValue<float>();
             // Wood door ~100%, steel (160hp) ~69%, granite (270hp) ~41%, plasteel (450hp) ~24%
-            var hpChance = 1/(door.HitPoints / 110.0f);
+            var hpChance = 1/(Math.Max(door.HitPoints, 1) / 110.0f);
             var unlockChance = Math.Min(nonMissChance, hpChance);
             
             if(Rand.Chance(unlockChance))

--- a/Source/RimWorld_Mechanoids/MoreMechanoids.csproj
+++ b/Source/RimWorld_Mechanoids/MoreMechanoids.csproj
@@ -38,6 +38,7 @@
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\RimWorldLinux_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HugsLib">
@@ -52,10 +53,12 @@
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\RimWorldLinux_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\RimWorldLinux_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Skullywag's now have a harder time opening doors made out of tougher materials.  They have a ~68% chance for steel doors and ~24% for plasteel doors on each attempt.

Discussion points:

- I left the call for GetNonMissChance in place, on the off-chance that damage to the skullywag would make it less effective at opening doors.
- The `110.0f` is a rough guess.  Wood doors are under that number of hit points, steel is above that value.

PS:
- Adds the hintpath's needed to compile under Linux
